### PR TITLE
Automatic VAT invoice sending via Stripe webhook

### DIFF
--- a/api/webhook.js
+++ b/api/webhook.js
@@ -1,0 +1,132 @@
+const stripe = require('stripe')(process.env.STRIPE_SECRET_KEY);
+
+// Vercel: disable body parsing so we get the raw bytes for signature verification
+module.exports.config = {
+  api: { bodyParser: false },
+};
+
+// ---------------------------------------------------------------------------
+// Raw body helper (needed for stripe.webhooks.constructEvent)
+// ---------------------------------------------------------------------------
+function getRawBody(req) {
+  return new Promise((resolve, reject) => {
+    const chunks = [];
+    req.on('data', (chunk) => chunks.push(chunk));
+    req.on('end', () => resolve(Buffer.concat(chunks)));
+    req.on('error', reject);
+  });
+}
+
+// ---------------------------------------------------------------------------
+// Main handler
+// ---------------------------------------------------------------------------
+module.exports = async function handler(req, res) {
+  if (req.method !== 'POST') {
+    return res.status(405).end('Method Not Allowed');
+  }
+
+  const rawBody = await getRawBody(req);
+  const sig = req.headers['stripe-signature'];
+
+  let event;
+  try {
+    event = stripe.webhooks.constructEvent(
+      rawBody,
+      sig,
+      process.env.STRIPE_WEBHOOK_SECRET
+    );
+  } catch (err) {
+    console.error('Webhook signature verification failed:', err.message);
+    return res.status(400).send(`Webhook Error: ${err.message}`);
+  }
+
+  if (event.type === 'checkout.session.completed') {
+    const session = event.data.object;
+    try {
+      await createAndSendVATInvoice(session);
+    } catch (err) {
+      console.error('Invoice creation failed:', err);
+      return res.status(500).json({ error: err.message });
+    }
+  }
+
+  return res.json({ received: true });
+};
+
+// ---------------------------------------------------------------------------
+// Create a VAT invoice for the completed session and send it to the customer
+// ---------------------------------------------------------------------------
+async function createAndSendVATInvoice(session) {
+  const email = session.customer_details?.email;
+  if (!email) {
+    console.warn('Session has no customer email — skipping invoice', session.id);
+    return;
+  }
+
+  // 1. Fetch the purchased line items
+  const { data: lineItems } = await stripe.checkout.sessions.listLineItems(
+    session.id,
+    { expand: ['data.price.product'], limit: 100 }
+  );
+
+  // 2. Get existing Stripe customer, or create one from the session details
+  let customerId = session.customer;
+  if (!customerId) {
+    const customer = await stripe.customers.create({
+      email,
+      name: session.customer_details.name || undefined,
+      address: session.customer_details.address || undefined,
+    });
+    customerId = customer.id;
+  }
+
+  // 3. Find or create the German VAT tax rate (19% exclusive)
+  const { data: existingRates } = await stripe.taxRates.list({ active: true, limit: 100 });
+  let vat = existingRates.find(
+    (t) => t.jurisdiction === 'DE' && t.percentage === 19 && !t.inclusive
+  );
+  if (!vat) {
+    vat = await stripe.taxRates.create({
+      display_name: 'MwSt (VAT)',
+      description: 'German VAT 19%',
+      jurisdiction: 'DE',
+      percentage: 19,
+      inclusive: false,
+    });
+  }
+
+  // 4. Add one invoice item per purchased line item
+  for (const item of lineItems) {
+    await stripe.invoiceItems.create({
+      customer: customerId,
+      amount: item.amount_total,
+      currency: item.currency,
+      description: item.description,
+      quantity: item.quantity ?? 1,
+      tax_rates: [vat.id],
+    });
+  }
+
+  // 5. Create the invoice
+  const invoice = await stripe.invoices.create({
+    customer: customerId,
+    collection_method: 'send_invoice',
+    days_until_due: 0,
+    auto_advance: false,
+    metadata: {
+      checkout_session_id: session.id,
+      payment_intent_id: session.payment_intent ?? '',
+    },
+  });
+
+  // 6. Finalize (locks the invoice and generates the PDF)
+  await stripe.invoices.finalizeInvoice(invoice.id);
+
+  // 7. Mark as paid — payment was already collected via the checkout session
+  await stripe.invoices.pay(invoice.id, { paid_out_of_band: true });
+
+  // 8. Send the invoice email to the customer
+  await stripe.invoices.sendInvoice(invoice.id);
+
+  console.log(`Invoice ${invoice.id} sent to ${email} for session ${session.id}`);
+}

--- a/package.json
+++ b/package.json
@@ -1,0 +1,8 @@
+{
+  "name": "bsides-berlin-webhooks",
+  "version": "1.0.0",
+  "private": true,
+  "dependencies": {
+    "stripe": "^17.0.0"
+  }
+}

--- a/vercel.json
+++ b/vercel.json
@@ -1,0 +1,8 @@
+{
+  "functions": {
+    "api/webhook.js": {
+      "memory": 128,
+      "maxDuration": 15
+    }
+  }
+}


### PR DESCRIPTION
## Summary

Adds a Vercel serverless function that listens for completed Stripe checkouts and automatically sends a German VAT (19% MwSt) invoice to the customer.

**New files:**
- `api/webhook.js` — the webhook handler
- `package.json` — `stripe` SDK dependency
- `vercel.json` — Vercel function config

**Flow on each ticket purchase:**
1. Stripe fires `checkout.session.completed`
2. Webhook fetches the session's line items
3. Gets or creates a Stripe Customer from the session details
4. Finds or creates a DE 19% MwSt tax rate
5. Creates invoice items with VAT applied
6. Creates, finalizes, and marks the invoice as paid (payment already collected)
7. Sends the invoice PDF to the customer's email

## Deployment steps

1. **Rotate your Stripe secret key** if you haven't already (the previous one was exposed)
2. Install Vercel CLI: `npm i -g vercel`
3. Run `vercel` in the repo root and follow the prompts to link/create a project
4. Set the two required environment variables in the Vercel dashboard (or via CLI):
   ```
   STRIPE_SECRET_KEY=sk_live_...       ← your new rotated key
   STRIPE_WEBHOOK_SECRET=whsec_...     ← from step 5
   ```
5. In the Stripe Dashboard → Developers → Webhooks → Add endpoint:
   - URL: `https://<your-vercel-deployment>.vercel.app/api/webhook`
   - Event: `checkout.session.completed`
   - Copy the signing secret → paste as `STRIPE_WEBHOOK_SECRET` in Vercel
6. Redeploy (`vercel --prod`) so the env vars take effect

## Test plan

- [ ] Stripe secret key has been rotated
- [ ] Vercel project linked and env vars set
- [ ] Webhook endpoint registered in Stripe Dashboard with `checkout.session.completed`
- [ ] Use Stripe CLI to send a test event: `stripe trigger checkout.session.completed`
- [ ] Confirm invoice email arrives with 19% MwSt line item
- [ ] Confirm invoice shows as paid in Stripe Dashboard

https://claude.ai/code/session_01TApi8TkC6SxzacQdtYd7UW