### PR TITLE
Add Socket sponsor, YouTube link, and HTML bug fixes

### DIFF
--- a/assets/css/style.css
+++ b/assets/css/style.css
@@ -1547,7 +1547,6 @@ h6 {
 @media (min-width: 768px) {
   #contact .contact-phone {
     border-left: 1px solid #ddd;
-    border-right: 1px solid #ddd;
   }
 }
 

--- a/index.html
+++ b/index.html
@@ -756,7 +756,7 @@
 
         <div class="section-header">
           <h2>Contact Us</h2>
-          <p>Feel free to drop us an email, or a message on X or LinkedIn</a></p>
+          <p>Feel free to drop us an email, or reach us on X, LinkedIn, or YouTube</p>
         </div>
 
 
@@ -774,6 +774,7 @@
           <div class="col-md-4">
             <div class="contact-phone">
               <i class="bi bi-twitter-x"></i>
+              <h3>X</h3>
               <p><a href="https://x.com/SidesBer" target="_blank">@SidesBer</a></p>
             </div>
           </div>
@@ -781,6 +782,7 @@
           <div class="col-md-4">
             <div class="contact-phone">
               <i class="bi bi-linkedin"></i>
+              <h3>LinkedIn</h3>
               <p><a href="https://www.linkedin.com/company/bsidesberlin" target="_blank">/company/bsidesberlin/</a></p>
             </div>
           </div>
@@ -788,6 +790,7 @@
           <div class="col-md-4">
             <div class="contact-phone">
               <i class="bi bi-youtube"></i>
+              <h3>YouTube</h3>
               <p><a href="https://www.youtube.com/channel/UCo4f878ExI673GzW9v7GgPQ" target="_blank">BSides Berlin on YouTube</a></p>
             </div>
           </div>


### PR DESCRIPTION
## Summary

- **Socket sponsor**: add inline SVG logo to `#supporters` section linking to https://socket.dev/ (inline SVG ensures gradient renders in all browsers); keep "contact us" sponsorship CTA below
- **YouTube**: add BSides Berlin YouTube channel link to hero and contact section
- **Contact section**: fix double divider between X and LinkedIn (removed `border-right` from `.contact-phone`); add consistent `<h3>` labels to X, LinkedIn, YouTube
- **HTML bug fixes**: deprecated `<font>` tag → inline style; extra `</a>` tags removed; Stuart McMurray broken Twitter link and stray `>` in alt fixed; all three committee member photos had `alt="LM"` → correct names; `target="blank"` → `target="_blank"` site-wide (9 occurrences)

## Test plan

- [ ] Sponsors section shows Socket logo with gradient and clicking opens socket.dev
- [ ] "Drop us an email" CTA still visible below logo
- [ ] Hero shows X, LinkedIn & YouTube links
- [ ] Contact section: all 5 boxes have icon + label + link, single dividers between columns
- [ ] Stuart McMurray Twitter link works
- [ ] All external links open in a new tab

https://claude.ai/code/session_01ERQAJjC54JXcHX6ziKbv6g

---
_Generated by [Claude Code](https://claude.ai/code/session_01ERQAJjC54JXcHX6ziKbv6g)_