### PR TITLE
Fix double divider in contact section (cache bust + explicit border-right: none)

### DIFF
--- a/assets/css/style.css
+++ b/assets/css/style.css
@@ -1547,6 +1547,7 @@ h6 {
 @media (min-width: 768px) {
   #contact .contact-phone {
     border-left: 1px solid #ddd;
+    border-right: none;
   }
 }
 

--- a/index.html
+++ b/index.html
@@ -24,7 +24,7 @@
   <link href="assets/vendor/swiper/swiper-bundle.min.css" rel="stylesheet">
 
   <!-- Template Main CSS File -->
-  <link href="assets/css/style.css" rel="stylesheet">
+  <link href="assets/css/style.css?v=2" rel="stylesheet">
 
   <style type="text/css">
 /*    .img-fluid {


### PR DESCRIPTION
Two changes to fix the persistent double divider between X and LinkedIn on desktop:

- Add `border-right: none` explicitly to `.contact-phone` so there's no ambiguity — the previous fix only removed `border-right` from the declaration but an explicit `none` is safer against cascade issues
- Add `?v=2` cache-busting query to the `style.css` link so browsers that cached the old CSS are forced to fetch the updated file

https://claude.ai/code/session_01ERQAJjC54JXcHX6ziKbv6g

---
_Generated by [Claude Code](https://claude.ai/code/session_01ERQAJjC54JXcHX6ziKbv6g)_