### PR TITLE
Add Buy Tickets section with price cards and Stripe disclaimer

### DIFF
--- a/index.html
+++ b/index.html
@@ -60,6 +60,7 @@
           <li><a class="nav-link scrollto" href="#venue">Venue</a></li>
           <li><a class="nav-link scrollto" href="#committee">Review committee</a></li>
           <li><a class="nav-link scrollto" href="#contact">Contact</a></li>
+          <li><a class="nav-link scrollto" href="#buy-tickets">Tickets</a></li>
         </ul>
         <i class="bi bi-list mobile-nav-toggle"></i>
       </nav><!-- .navbar -->
@@ -634,120 +635,97 @@
 
     </section>
 
-    <!-- ======= Buy Ticket Section ======= -->
-  <!--<section id="buy-tickets" class="section-with-bg">
-  <div class="container" data-aos="fade-up">
+    <!-- ======= Buy Tickets Section ======= -->
+    <section id="buy-tickets" class="section-with-bg">
+      <div class="container" data-aos="fade-up">
 
-    <div class="section-header" style="border-bottom: none; margin-bottom: 0;">
-      <h2>Buy Tickets</h2>
-
-      <!-- Ticket Tailor Widget -->
-      <!--<div class="tt-widget" style="margin-bottom: 0;">
-        <div class="tt-widget-fallback">
-          <p><a href="https://www.tickettailor.com/all-tickets/ticktechtalksug/?ref=website_widget&show_search_filter=true&show_date_filter=true&show_sort=true" target="_blank">Click here to buy tickets</a><br />
-            <small><a href="https://www.tickettailor.com?rf=wdg_258486" class="tt-widget-powered">Sell tickets online with Ticket Tailor</a></small>
-          </p>
+        <div class="section-header">
+          <h2>Buy Tickets</h2>
         </div>
-        <script src="https://cdn.tickettailor.com/js/widgets/min/widget.js" data-url="https://www.tickettailor.com/all-tickets/ticktechtalksug/?ref=website_widget&show_search_filter=true&show_date_filter=true&show_sort=true" data-type="inline" data-inline-minimal="true" data-inline-show-logo="false" data-inline-bg-fill="false" data-inline-inherit-ref-from-url-param="" data-inline-ref="website_widget"></script>
-      </div>
-      <!-- End of Ticket Tailor Widget -->
-    </div>
 
-    <!-- Ticket Cards -->
-    <!--<div class="row justify-content-center">
-      <!-- Student -->
-      <!--<div class="col-lg-3 col-md-6 mb-4" data-aos="fade-up" data-aos-delay="200">
-        <div class="card h-100">
-          <div class="card-body">
-            <h5 class="card-title text-muted text-uppercase text-center">Student pass</h5>
-            <h6 class="card-price text-center">€49</h6>
-            <h6 class="text-center"><small>excl. VAT and booking fee</small></h6>
-            <ul class="fa-ul mt-3 mb-3">
-              <li><span class="fa-li"><i class="fa fa-check"></i></span>Access to all talks</li>
-              <li><span class="fa-li"><i class="fa fa-check"></i></span>Lunch & Coffee Break</li>
-              <li><span class="fa-li"><i class="fa fa-check"></i></span><b>You need to show your student ID</b></li>
-            </ul>
+        <div class="row justify-content-center">
+
+          <div class="col-lg-3 col-md-6 mb-4" data-aos="fade-up" data-aos-delay="200">
+            <div class="card h-100">
+              <div class="card-body text-center">
+                <h5 class="card-title text-muted text-uppercase">Student Pass</h5>
+                <h6 class="card-price">€49</h6>
+                <p class="text-muted"><small>excl. VAT and booking fee</small></p>
+                <ul class="list-unstyled mt-3 mb-3 text-start">
+                  <li><i class="bi bi-check-lg text-danger"></i> Access to all talks</li>
+                  <li><i class="bi bi-check-lg text-danger"></i> Lunch &amp; Coffee Break</li>
+                  <li><i class="bi bi-check-lg text-danger"></i> <b>Student ID required</b></li>
+                </ul>
+              </div>
+            </div>
+          </div>
+
+          <div class="col-lg-3 col-md-6 mb-4" data-aos="fade-up" data-aos-delay="250">
+            <div class="card h-100">
+              <div class="card-body text-center">
+                <h5 class="card-title text-muted text-uppercase">Self Payer</h5>
+                <h6 class="card-price">€99</h6>
+                <p class="text-muted"><small>excl. VAT and booking fee</small></p>
+                <ul class="list-unstyled mt-3 mb-3 text-start">
+                  <li><i class="bi bi-check-lg text-danger"></i> Access to all talks</li>
+                  <li><i class="bi bi-check-lg text-danger"></i> Lunch &amp; Coffee Break</li>
+                </ul>
+              </div>
+            </div>
+          </div>
+
+          <div class="col-lg-3 col-md-6 mb-4" data-aos="fade-up" data-aos-delay="300">
+            <div class="card h-100">
+              <div class="card-body text-center">
+                <h5 class="card-title text-muted text-uppercase">Business</h5>
+                <h6 class="card-price">€175</h6>
+                <p class="text-muted"><small>excl. VAT and booking fee</small></p>
+                <ul class="list-unstyled mt-3 mb-3 text-start">
+                  <li><i class="bi bi-check-lg text-danger"></i> Access to all talks</li>
+                  <li><i class="bi bi-check-lg text-danger"></i> Lunch &amp; Coffee Break</li>
+                  <li><i class="bi bi-check-lg text-danger"></i> <b>Invoice for company reimbursement</b></li>
+                </ul>
+              </div>
+            </div>
+          </div>
+
+          <div class="col-lg-3 col-md-6 mb-4" data-aos="fade-up" data-aos-delay="350">
+            <div class="card h-100">
+              <div class="card-body text-center">
+                <h5 class="card-title text-muted text-uppercase">Supporter</h5>
+                <h6 class="card-price">€250</h6>
+                <p class="text-muted"><small>excl. VAT and booking fee</small></p>
+                <ul class="list-unstyled mt-3 mb-3 text-start">
+                  <li><i class="bi bi-check-lg text-danger"></i> <b>Helps fund the event</b></li>
+                  <li><i class="bi bi-check-lg text-danger"></i> Access to all talks</li>
+                  <li><i class="bi bi-check-lg text-danger"></i> Lunch &amp; Coffee Break</li>
+                  <li><i class="bi bi-check-lg text-danger"></i> <b>Invoice for company reimbursement</b></li>
+                </ul>
+              </div>
+            </div>
+          </div>
+
+        </div>
+
+        <div class="row justify-content-center mt-3">
+          <div class="col-lg-8 text-center">
+            <a href="https://buy.stripe.com/00geX4dPM8LqgWQ4gh" class="buy-tickets" target="_blank">
+              <i class="bi bi-ticket-perforated-fill"></i> Buy Tickets
+            </a>
+            <p class="mt-3"><small><strong>Please note:</strong> The payment link automatically adds one of each ticket type to your basket. Remove the ticket types you don't need before completing your purchase.</small></p>
           </div>
         </div>
-      </div>
 
-      <!-- Self Payer -->
-      <!--<div class="col-lg-3 col-md-6 mb-4" data-aos="fade-up" data-aos-delay="250">
-        <div class="card h-100">
-          <div class="card-body">
-            <h5 class="card-title text-muted text-uppercase text-center">Self Payer</h5>
-            <h6 class="card-price text-center">€99</h6>
-            <h6 class="text-center"><small>excl. VAT and booking fee</small></h6>
-            <ul class="fa-ul mt-3 mb-3">
-              <li><span class="fa-li"><i class="fa fa-check"></i></span>Access to all talks</li>
-              <li><span class="fa-li"><i class="fa fa-check"></i></span>Lunch & Coffee Break</li>
-            </ul>
+        <div class="row justify-content-center mt-3">
+          <div class="col-lg-8">
+            <div class="alert alert-info text-center" role="alert">
+              <strong>Cancellation &amp; Refund Policy:</strong> Refunds are available for cancellations made up to <strong>30 days prior to the event</strong>. Booking and payment processing fees charged by Stripe are <strong>non-refundable</strong>.
+            </div>
           </div>
         </div>
+
       </div>
-
-      <!-- Business -->
-      <!--<div class="col-lg-3 col-md-6 mb-4" data-aos="fade-up" data-aos-delay="300">
-        <div class="card h-100">
-          <div class="card-body">
-            <h5 class="card-title text-muted text-uppercase text-center">Business ticket</h5>
-            <h6 class="card-price text-center">€175</h6>
-            <h6 class="text-center"><small>excl. VAT and booking fee</small></h6>
-            <ul class="fa-ul mt-3 mb-3">
-              <li><span class="fa-li"><i class="fa fa-check"></i></span>Access to all talks</li>
-              <li><span class="fa-li"><i class="fa fa-check"></i></span>Lunch & Coffee Break</li>
-              <li><span class="fa-li"><i class="fa fa-check"></i></span><b>Invoice for company reimbursement</b></li>
-            </ul>
-          </div>
-        </div>
-      </div>
-
-      <!-- Supporter -->
-      <!--<div class="col-lg-3 col-md-6 mb-4" data-aos="fade-up" data-aos-delay="350">
-        <div class="card h-100">
-          <div class="card-body">
-            <h5 class="card-title text-muted text-uppercase text-center">Supporter Ticket</h5>
-            <h6 class="card-price text-center">€250</h6>
-            <h6 class="text-center"><small>excl. VAT and booking fee</small></h6>
-            <ul class="fa-ul mt-3 mb-3">
-              <li><span class="fa-li"><i class="fa fa-check"></i></span><b>Helps fund the event</b></li>
-              <li><span class="fa-li"><i class="fa fa-check"></i></span>Access to all talks</li>
-              <li><span class="fa-li"><i class="fa fa-check"></i></span>Lunch & Coffee Break</li>
-              <li><span class="fa-li"><i class="fa fa-check"></i></span><b>Invoice for company reimbursement</b></li>
-            </ul>
-          </div>
-        </div>
-      </div>
-    </div>
-    </div> <!-- End of Ticket Cards -->
-
-    <!-- Refund Policy Notice -->
-    <!--<div class="row justify-content-center mt-4">
-      <div class="col-lg-10">
-        <div class="alert alert-info text-center" role="alert" style="font-size: 0.95rem;">
-          <strong>Cancellation & Refund Policy:</strong> Refunds are available for cancellations made up to <strong>30 days prior to the event</strong>. Please note that booking and payment processing fees charged by third-party providers (Ticket Tailor and Stripe) are <strong>non-refundable</strong>.
-        </div>
-      </div>
-    </div>
-
-    <!-- Modal Order Form -->
-
-    <!-- Modal Order Form -->
-    <!--<div id="buy-ticket-modal" class="modal fade">
-      <div class="modal-dialog" role="document">
-        <div class="modal-content">
-          <div class="modal-header">
-            <h4 class="modal-title">Ticket Sale Coming Soon</h4>
-            <button type="button" class="btn-close" data-bs-dismiss="modal" aria-label="Close"></button>
-          </div>
-          <div class="modal-body">
-          </div>
-        </div>
-      </div>
-    </div>
-
-  </div>
-</section>
+    </section><!-- End Buy Tickets Section -->
 
     <!-- ======= Contact Section ======= -->
     <section id="contact" class="section-bg">


### PR DESCRIPTION
## Summary

- Makes the `#buy-tickets` section visible (replaces the old nested comment mess with clean HTML)
- Shows all 4 ticket tiers with prices: **Student €49 / Self Payer €99 / Business €175 / Supporter €250**
- Single **Buy Tickets** button links to the existing Stripe URL
- Disclaimer below the button: *"The payment link automatically adds one of each ticket type to your basket. Remove the ticket types you don't need before completing your purchase."*
- Cancellation & refund policy notice
- Adds **Tickets** link to the navbar

## Test plan

- [ ] Ticket section is visible on the page
- [ ] All 4 cards show correct prices and feature lists
- [ ] Buy Tickets button opens the Stripe link in a new tab
- [ ] Disclaimer text is visible below the button
- [ ] Refund policy alert is shown
- [ ] "Tickets" appears in the navbar and scrolls to the section

https://claude.ai/code/session_01ERQAJjC54JXcHX6ziKbv6g

---
_Generated by [Claude Code](https://claude.ai/code/session_01ERQAJjC54JXcHX6ziKbv6g)_