### PR TITLE
Add sponsor section, buy tickets, UI polish, and imprint page

### DIFF
--- a/imprint.html
+++ b/imprint.html
@@ -1,0 +1,119 @@
+<!DOCTYPE html>
+<html lang="en">
+
+<head>
+  <meta charset="utf-8">
+  <meta content="width=device-width, initial-scale=1.0" name="viewport">
+
+  <title>BSides Berlin – Imprint / Impressum</title>
+  <meta content="" name="description">
+  <meta content="" name="keywords">
+
+  <!-- Favicons -->
+  <link href="assets/img/favicon.png" rel="icon">
+  <link href="assets/img/apple-touch-icon.png" rel="apple-touch-icon">
+
+  <!-- Google Fonts -->
+  <link href="https://fonts.googleapis.com/css?family=Open+Sans:300,300i,400,400i,700,700i|Raleway:300,400,500,700,800" rel="stylesheet">
+
+  <!-- Vendor CSS Files -->
+  <link href="assets/vendor/aos/aos.css" rel="stylesheet">
+  <link href="assets/vendor/bootstrap/css/bootstrap.min.css" rel="stylesheet">
+  <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap-icons@1.11.3/font/bootstrap-icons.css">
+  <link href="assets/vendor/glightbox/css/glightbox.min.css" rel="stylesheet">
+  <link href="assets/vendor/swiper/swiper-bundle.min.css" rel="stylesheet">
+
+  <!-- Template Main CSS File -->
+  <link href="assets/css/style.css?v=4" rel="stylesheet">
+</head>
+
+<body>
+
+  <!-- ======= Header ======= -->
+  <header id="header" class="d-flex align-items-center header-inner">
+    <div class="container-fluid container-xxl d-flex align-items-center justify-content-between">
+
+      <div id="logo">
+        <a href="index.html"><img src="assets/img/logo.png" alt="BSides Berlin"></a>
+      </div>
+
+      <nav id="navbar" class="navbar order-last order-lg-0">
+        <ul>
+          <li><a class="nav-link" href="index.html">Home</a></li>
+          <li><a class="nav-link" href="index.html#about">About</a></li>
+          <li><a class="nav-link" href="index.html#venue">Venue</a></li>
+          <li><a class="nav-link" href="index.html#committee">Review committee</a></li>
+          <li><a class="nav-link" href="index.html#contact">Contact</a></li>
+        </ul>
+        <i class="bi bi-list mobile-nav-toggle"></i>
+      </nav>
+
+    </div>
+  </header><!-- End Header -->
+
+  <main id="main">
+
+    <section style="padding: 80px 0;">
+      <div class="container">
+
+        <div class="section-header">
+          <h2>Imprint</h2>
+          <p>Impressum</p>
+        </div>
+
+        <div class="row justify-content-center">
+          <div class="col-lg-8">
+
+            <h5 class="mb-1" style="font-weight: 600; color: #0e1b4d;">Legal entity</h5>
+            <p>Tick Tech Talks UG (haftungsbeschränkt)</p>
+
+            <h5 class="mb-1" style="font-weight: 600; color: #0e1b4d;">Address</h5>
+            <p>Danneckerstr. 14<br>10245 Berlin, Germany</p>
+
+            <h5 class="mb-1" style="font-weight: 600; color: #0e1b4d;">Contact</h5>
+            <p><a href="mailto:team+impressum@gophercon.eu">team+impressum@gophercon.eu</a></p>
+
+            <h5 class="mb-1" style="font-weight: 600; color: #0e1b4d;">Court registration</h5>
+            <p>Amtsgericht Charlottenburg (Berlin)<br>HRB 195529 B</p>
+
+            <h5 class="mb-1" style="font-weight: 600; color: #0e1b4d;">VAT identification number</h5>
+            <p>UST-ID: DE317299628</p>
+
+            <h5 class="mb-1" style="font-weight: 600; color: #0e1b4d;">Legal documents</h5>
+            <p><a href="https://docs.google.com/document/d/1Sb1pDJTd6GcD-Uq4dU2_6m57tuVssWvVmgvMM1of7lk/edit?usp=sharing" target="_blank" rel="noopener">Privacy Policy / Terms of Use</a></p>
+
+          </div>
+        </div>
+
+      </div>
+    </section>
+
+  </main><!-- End #main -->
+
+  <!-- ======= Footer ======= -->
+  <footer id="footer">
+    <div class="container">
+      <div class="copyright">
+        &copy; Copyright <strong>BSides Berlin</strong>. All Rights Reserved
+      </div>
+      <div class="credits">
+        <a href="imprint.html">Imprint</a> &nbsp;·&nbsp;
+        Designed by <a href="https://bootstrapmade.com/">BootstrapMade</a>
+      </div>
+    </div>
+  </footer><!-- End Footer -->
+
+  <a href="#" class="back-to-top d-flex align-items-center justify-content-center"><i class="bi bi-arrow-up-short"></i></a>
+
+  <!-- Vendor JS Files -->
+  <script src="assets/vendor/aos/aos.js"></script>
+  <script src="assets/vendor/bootstrap/js/bootstrap.bundle.min.js"></script>
+  <script src="assets/vendor/glightbox/js/glightbox.min.js"></script>
+  <script src="assets/vendor/swiper/swiper-bundle.min.js"></script>
+
+  <!-- Template Main JS File -->
+  <script src="assets/js/main.js"></script>
+
+</body>
+
+</html>

--- a/index.html
+++ b/index.html
@@ -789,27 +789,16 @@
 
   <!-- ======= Footer ======= -->
   <footer id="footer">
-          <div class="col-md-4">
-              <ul class="fa-ul">
-              <b>Imprint / Impressum:</b>
-              <li>Tick Tech Talks UG (haftungsbeschränkt)</li>
-              <li>Danneckerstr. 14 10245, Berlin, Germany</li>
-              <li>team+impressum@gophercon.eu</li>
-              <li>Amtsgericht Charlottenburg (Berlin) HRB 195529 B</li>
-              <li>UST-ID: DE317299628</li>
-              <li><a href= "https://docs.google.com/document/d/1Sb1pDJTd6GcD-Uq4dU2_6m57tuVssWvVmgvMM1of7lk/edit?usp=sharing">Privacy Policy/Terms of Use</li>   
-            </ul>
-            </div>
-          </div>
     <div class="container">
       <div class="copyright">
-        &copy; Copyright <strong>TheEvent</strong>. All Rights Reserved
+        &copy; Copyright <strong>BSides Berlin</strong>. All Rights Reserved
       </div>
       <div class="credits">
+        <a href="imprint.html">Imprint</a> &nbsp;·&nbsp;
         Designed by <a href="https://bootstrapmade.com/">BootstrapMade</a>
       </div>
     </div>
-  </footer><!-- End  Footer -->
+  </footer><!-- End Footer -->
 
   <a href="#" class="back-to-top d-flex align-items-center justify-content-center"><i class="bi bi-arrow-up-short"></i></a>
 


### PR DESCRIPTION
## Summary

- Added Socket as a sponsor with inline SVG logo linking to https://socket.dev/
- Added Buy Tickets section with price cards (Student €49, Self Payer €99, Business €175, Supporter €250), Stripe button, and basket disclaimer
- Both Buy Tickets buttons (header + hero) now scroll to the `#buy-tickets` section
- Added YouTube channel link to contact section
- Fixed all known HTML bugs (broken Stuart McMurray link, alt text errors, deprecated font tag, `target="blank"` → `target="_blank"`, unclosed tags)
- Fixed double divider between X and LinkedIn in contact section
- Added consistent h3 labels to all contact boxes
- Changed LinkedIn link text to "BSides Berlin"
- CSS-only UI polish: refined typography, spacing, section headers, card shadows — same color scheme
- Moved imprint content to dedicated `imprint.html` page; footer now shows a simple "Imprint" link
- Updated footer copyright from "TheEvent" to "BSides Berlin"

## Test plan

- [ ] Verify Socket logo renders with gradient on the supporters section
- [ ] Verify Buy Tickets price cards display correctly on desktop and mobile
- [ ] Verify both Buy Tickets buttons scroll to `#buy-tickets` section
- [ ] Verify YouTube link opens correct channel
- [ ] Verify `imprint.html` loads and displays all legal details
- [ ] Verify footer shows "Imprint" link only (no inline legal text)
- [ ] Check mobile responsiveness across all sections

https://claude.ai/code/session_01ERQAJjC54JXcHX6ziKbv6g

---
_Generated by [Claude Code](https://claude.ai/code/session_01ERQAJjC54JXcHX6ziKbv6g)_